### PR TITLE
fix: composite action path handling during upgrade

### DIFF
--- a/internal/actions/actions.go
+++ b/internal/actions/actions.go
@@ -95,12 +95,15 @@ func (c *Client) GetCacheStats() CacheStats {
 type ActionInfo struct {
 	Owner      string
 	Repo       string
+	Path       string // Subdirectory path for composite actions (e.g., "upload-sarif")
 	Ref        string
 	CommitHash string
 	Tag        string
 }
 
-// ParseActionUses parses "owner/repo@ref" into ActionInfo.
+// ParseActionUses parses "owner/repo@ref" or "owner/repo/path@ref" into ActionInfo.
+// For composite actions like "github/codeql-action/upload-sarif@v2", the repo
+// is extracted as "codeql-action" and path as "upload-sarif".
 func ParseActionUses(uses string) (*ActionInfo, error) {
 	atIdx := strings.LastIndex(uses, "@")
 	if atIdx == -1 {
@@ -110,14 +113,31 @@ func ParseActionUses(uses string) (*ActionInfo, error) {
 	actionPath := uses[:atIdx]
 	ref := uses[atIdx+1:]
 
-	slashIdx := strings.Index(actionPath, "/")
-	if slashIdx == -1 {
+	// Find first slash for owner
+	firstSlash := strings.Index(actionPath, "/")
+	if firstSlash == -1 {
 		return nil, fmt.Errorf("invalid action path: %s", actionPath)
 	}
 
+	owner := actionPath[:firstSlash]
+	rest := actionPath[firstSlash+1:]
+
+	// Check for second slash (composite action path)
+	secondSlash := strings.Index(rest, "/")
+	var repo, path string
+	if secondSlash == -1 {
+		// Simple case: owner/repo@ref
+		repo = rest
+	} else {
+		// Composite action: owner/repo/path@ref
+		repo = rest[:secondSlash]
+		path = rest[secondSlash+1:]
+	}
+
 	return &ActionInfo{
-		Owner: actionPath[:slashIdx],
-		Repo:  actionPath[slashIdx+1:],
+		Owner: owner,
+		Repo:  repo,
+		Path:  path,
 		Ref:   ref,
 	}, nil
 }

--- a/internal/actions/actions_test.go
+++ b/internal/actions/actions_test.go
@@ -8,6 +8,7 @@ func TestParseActionUses(t *testing.T) {
 		input       string
 		wantOwner   string
 		wantRepo    string
+		wantPath    string
 		wantRef     string
 		expectError bool
 	}{
@@ -16,6 +17,7 @@ func TestParseActionUses(t *testing.T) {
 			input:     "actions/checkout@v3",
 			wantOwner: "actions",
 			wantRepo:  "checkout",
+			wantPath:  "",
 			wantRef:   "v3",
 		},
 		{
@@ -23,6 +25,7 @@ func TestParseActionUses(t *testing.T) {
 			input:     "actions/setup-go@4ab4c1d02e2b3d0af1e9f9c2a3b2c3d4e5f6a7b8c9",
 			wantOwner: "actions",
 			wantRepo:  "setup-go",
+			wantPath:  "",
 			wantRef:   "4ab4c1d02e2b3d0af1e9f9c2a3b2c3d4e5f6a7b8c9",
 		},
 		{
@@ -30,7 +33,24 @@ func TestParseActionUses(t *testing.T) {
 			input:     "codecov/codecov-action@v3.1.4",
 			wantOwner: "codecov",
 			wantRepo:  "codecov-action",
+			wantPath:  "",
 			wantRef:   "v3.1.4",
+		},
+		{
+			name:      "composite action with path",
+			input:     "github/codeql-action/upload-sarif@v2",
+			wantOwner: "github",
+			wantRepo:  "codeql-action",
+			wantPath:  "upload-sarif",
+			wantRef:   "v2",
+		},
+		{
+			name:      "composite action with deep path",
+			input:     "aws-actions/configure-aws-credentials/assume-role@v4",
+			wantOwner: "aws-actions",
+			wantRepo:  "configure-aws-credentials",
+			wantPath:  "assume-role",
+			wantRef:   "v4",
 		},
 		{
 			name:        "missing @",
@@ -75,6 +95,9 @@ func TestParseActionUses(t *testing.T) {
 			}
 			if result.Repo != tt.wantRepo {
 				t.Errorf("ParseActionUses(%q).Repo = %q, want %q", tt.input, result.Repo, tt.wantRepo)
+			}
+			if result.Path != tt.wantPath {
+				t.Errorf("ParseActionUses(%q).Path = %q, want %q", tt.input, result.Path, tt.wantPath)
 			}
 			if result.Ref != tt.wantRef {
 				t.Errorf("ParseActionUses(%q).Ref = %q, want %q", tt.input, result.Ref, tt.wantRef)

--- a/internal/upgrader/upgrader.go
+++ b/internal/upgrader/upgrader.go
@@ -249,7 +249,13 @@ func (u *Upgrader) getLatestVersion(cfg *config.Config, info *actions.ActionInfo
 func (u *Upgrader) applyUpdate(upd updateInfo) error {
 	newRef, comment := u.formatVersion(upd)
 
-	newUses := fmt.Sprintf("%s/%s@%s", upd.ActionInfo.Owner, upd.ActionInfo.Repo, newRef)
+	// Build the new uses string, preserving path for composite actions
+	var newUses string
+	if upd.ActionInfo.Path != "" {
+		newUses = fmt.Sprintf("%s/%s/%s@%s", upd.ActionInfo.Owner, upd.ActionInfo.Repo, upd.ActionInfo.Path, newRef)
+	} else {
+		newUses = fmt.Sprintf("%s/%s@%s", upd.ActionInfo.Owner, upd.ActionInfo.Repo, newRef)
+	}
 	if err := upd.Workflow.UpdateActionUses(upd.Action.Uses, newUses, comment); err != nil {
 		return fmt.Errorf("failed to update action in %s: %w", upd.Workflow.File, err)
 	}


### PR DESCRIPTION
Fixes an issue where composite actions (e.g., `github/codeql-action/upload-sarif@v2`) were not handled correctly during upgrades.